### PR TITLE
Make GitHub detect *.fb, *.fbs, and *.fsb as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.fb linguist-language=Forth
+*.fbs linguist-language=Forth
+*.fsb linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.fb`, `.fbs`, and `.fsb` files as Forth.

Thanks!
